### PR TITLE
support dynamic load module

### DIFF
--- a/config
+++ b/config
@@ -5,3 +5,9 @@ NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/src/ngx_coolkit_handlers.c $ngx_a
 NGX_ADDON_DEPS="$NGX_ADDON_DEPS $ngx_addon_dir/src/ngx_coolkit_handlers.h $ngx_addon_dir/src/ngx_coolkit_module.h $ngx_addon_dir/src/ngx_coolkit_variables.h"
 
 have=NGX_COOLKIT_MODULE . auto/have
+if test -n "$ngx_module_link"; then
+    ngx_module_type=HTTP
+    ngx_module_name="$ngx_addon_name"
+    ngx_module_srcs="$NGX_ADDON_SRCS"
+    . auto/module
+fi


### PR DESCRIPTION
Add new format of `config` to support compiling as either a static or dynamic module.
Refer to https://www.nginx.com/resources/wiki/extending/new_config